### PR TITLE
Build plugin after every push

### DIFF
--- a/.github/workflows/build-plugin-master.yml
+++ b/.github/workflows/build-plugin-master.yml
@@ -1,0 +1,34 @@
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java#publishing-using-gradle
+
+name: Build Nightly
+
+on:
+  push:
+    branches: 
+      - master
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Gradle
+      run: gradle build && find
+    
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        # Artifact name
+        name: Polo Nightly
+        # A file, directory or wildcard pattern that describes what to upload
+        path: ./polo-bukkit/build/libs/polo-bukkit-1.0.0-all.jar

--- a/polo-bukkit/src/main/resources/plugin.yml
+++ b/polo-bukkit/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: polo
 version: '1.0.0'
 author: 'Dylan Hackworth'
-main: 'dev.dhdf.polo.Main'
+main: 'dev.dhdf.polo.bukkit.Main'
 api-version: '1.15'


### PR DESCRIPTION
This takes ~50 seconds of github action time. You have 2 000 minutes available every month.

Also fixes plugin not starting up